### PR TITLE
[004-Account-Update] 잔액 사용

### DIFF
--- a/src/main/java/com/example/Account/controller/TransactionController.java
+++ b/src/main/java/com/example/Account/controller/TransactionController.java
@@ -1,0 +1,49 @@
+package com.example.Account.controller;
+
+/*
+ * 잔액 관련 컨트롤러
+ * 1. 잔액 사용
+ * 2. 잔액 사용 취소
+ * 3. 거래 확인
+ */
+
+import com.example.Account.dto.UseBalance;
+import com.example.Account.exception.AccountException;
+import com.example.Account.service.TransactionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class TransactionController {
+
+    private final TransactionService transactionService;
+
+    @PostMapping("/transaction/use")
+    public UseBalance.Response useBalance(
+            @Valid @RequestBody UseBalance.Request request
+    ) {
+        try {
+            return UseBalance.Response.from(
+                    transactionService.useBalance(request.getUserId(),
+                            request.getAccountNumber(), request.getAmount())
+            );
+        } catch (AccountException e) {
+            log.error("Failed to use balance.");
+
+            transactionService.saveFailedUseTransaction(
+                    request.getAccountNumber(),
+                    request.getAmount()
+            );
+
+            throw e;
+        }
+    }
+
+}

--- a/src/main/java/com/example/Account/domain/Account.java
+++ b/src/main/java/com/example/Account/domain/Account.java
@@ -3,6 +3,8 @@
 
 package com.example.Account.domain;
 
+import com.example.Account.exception.AccountException;
+import com.example.Account.type.ErrorCode;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -40,4 +42,11 @@ public class Account {
 
     @LastModifiedDate
     private LocalDateTime updatedAt;
+
+    public void useBalance(Long amount) {
+        if (amount> balance){
+            throw new AccountException(ErrorCode.AMOUNT_EXCEED_BALANCE);
+        }
+        balance -= amount;
+    }
 }

--- a/src/main/java/com/example/Account/domain/Transaction.java
+++ b/src/main/java/com/example/Account/domain/Transaction.java
@@ -1,0 +1,42 @@
+package com.example.Account.domain;
+
+import com.example.Account.type.TransactionResultType;
+import com.example.Account.type.TransactionType;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class Transaction {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private TransactionType transactionType;
+    @Enumerated(EnumType.STRING)
+    private TransactionResultType transactionResultType;
+
+    @ManyToOne
+    private Account account;
+    private Long amount;
+    private Long balanceSnapshot;
+
+    private String transactionId;
+    private LocalDateTime transactedAt;
+
+    @CreatedDate
+    private LocalDateTime createAt;
+    @LastModifiedDate
+    private LocalDateTime updateAt;
+}

--- a/src/main/java/com/example/Account/dto/TransactionDto.java
+++ b/src/main/java/com/example/Account/dto/TransactionDto.java
@@ -1,0 +1,35 @@
+package com.example.Account.dto;
+
+import com.example.Account.domain.Transaction;
+import com.example.Account.type.TransactionResultType;
+import com.example.Account.type.TransactionType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TransactionDto {
+    private String accountNumber;
+    private TransactionType transactionType;
+    private TransactionResultType transactionResultType;
+    private Long amount;
+    private Long balanceSnapshot;
+    private String transactionId;
+    private LocalDateTime transactedAt;
+
+    public static TransactionDto fromEntity(Transaction transaction) {
+        return TransactionDto.builder()
+                .accountNumber(transaction.getAccount().getAccountNumber())
+                .transactionType(transaction.getTransactionType())
+                .transactionResultType(transaction.getTransactionResultType())
+                .amount(transaction.getAmount())
+                .balanceSnapshot(transaction.getBalanceSnapshot())
+                .transactionId(transaction.getTransactionId())
+                .transactedAt(transaction.getTransactedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/Account/dto/UseBalance.java
+++ b/src/main/java/com/example/Account/dto/UseBalance.java
@@ -1,0 +1,50 @@
+package com.example.Account.dto;
+
+import com.example.Account.type.TransactionResultType;
+import lombok.*;
+
+import javax.validation.constraints.*;
+import java.time.LocalDateTime;
+
+public class UseBalance {
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class Request {
+        @NotNull
+        @Min(1)
+        private Long userId;
+
+        @NotBlank
+        @Size(min = 10, max = 10)
+        private String accountNumber;
+
+        @NotNull
+        @Min(10)
+        @Max(1000_000_000)
+        private Long amount;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+        private String accountNumber;
+        private TransactionResultType transactionResult;
+        private String transactionId;
+        private Long amount;
+        private LocalDateTime transactedAt;
+
+        public static UseBalance.Response from(TransactionDto transactionDto) {
+            return Response.builder()
+                    .accountNumber(transactionDto.getAccountNumber())
+                    .transactionResult(transactionDto.getTransactionResultType())
+                    .transactionId(transactionDto.getTransactionId())
+                    .amount(transactionDto.getAmount())
+                    .transactedAt(transactionDto.getTransactedAt())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/example/Account/repository/TransactionRepository.java
+++ b/src/main/java/com/example/Account/repository/TransactionRepository.java
@@ -1,0 +1,12 @@
+package com.example.Account.repository;
+
+import com.example.Account.domain.Transaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface TransactionRepository extends JpaRepository<Transaction, Long> {//<활용할 엔티티, pk 데이터 타입>
+    Optional<Transaction> findByTransactionId(String transactionId);
+}

--- a/src/main/java/com/example/Account/service/TransactionService.java
+++ b/src/main/java/com/example/Account/service/TransactionService.java
@@ -1,0 +1,92 @@
+package com.example.Account.service;
+
+import com.example.Account.domain.Account;
+import com.example.Account.domain.AccountStatus;
+import com.example.Account.domain.AccountUser;
+import com.example.Account.domain.Transaction;
+import com.example.Account.dto.TransactionDto;
+import com.example.Account.exception.AccountException;
+import com.example.Account.repository.AccountRepository;
+import com.example.Account.repository.AccountUserRepository;
+import com.example.Account.repository.TransactionRepository;
+import com.example.Account.type.ErrorCode;
+import com.example.Account.type.TransactionResultType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.UUID;
+
+import static com.example.Account.type.TransactionResultType.F;
+import static com.example.Account.type.TransactionResultType.S;
+import static com.example.Account.type.TransactionType.CANCEL;
+import static com.example.Account.type.TransactionType.USE;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TransactionService {
+    private final TransactionRepository transactionRepository;
+    private final AccountUserRepository accountUserRepository;
+    private final AccountRepository accountRepository;
+
+    /**
+     * 사용자가 없는 경우, 계좌가 없는 경우, 사용자 아이디와 계좌 소유주가 다른 경우,
+     * 계좌가 이미 해지 상태인 경우, 거래 금액이 잔액보다 큰 경우,
+     * 거래 금액이 너무 작거나 큰 경우 실패 응답
+     */
+    @Transactional
+    public TransactionDto useBalance(Long userId, String accountNumber,
+                                     Long amount) {
+        AccountUser user = accountUserRepository.findById(userId)
+                .orElseThrow(() -> new AccountException(ErrorCode.USER_NOT_FOUND));
+
+        Account account = accountRepository.findByAccountNumber(accountNumber)
+                .orElseThrow(() -> new AccountException(ErrorCode.ACCOUNT_NOT_FOUND));
+
+        validateUseBalance(user, account, amount);
+
+        account.useBalance(amount);
+
+        return TransactionDto.fromEntity(saveAndGetTransaction(S, account, amount));
+    }
+
+
+    private void validateUseBalance(AccountUser user, Account account, Long amount) {
+        if (!Objects.equals(user.getId(), account.getAccountUser().getId())) {
+            throw new AccountException(ErrorCode.USER_ACCOUNT_UN_MATCH);
+        }
+        if (account.getAccountStatus() != AccountStatus.IN_USE) {
+            throw new AccountException(ErrorCode.ACCOUNT_ALREADY_UNREGISTERED);
+        }
+        if (account.getBalance() < amount) {
+            throw new AccountException(ErrorCode.AMOUNT_EXCEED_BALANCE);
+        }
+    }
+
+    private Transaction saveAndGetTransaction(
+            TransactionResultType transactionResultType,
+            Account account,
+            Long amount) {
+        return transactionRepository.save(
+                Transaction.builder()
+                        .transactionType(USE)
+                        .transactionResultType(transactionResultType)
+                        .account(account)
+                        .amount(amount)
+                        .balanceSnapshot(account.getBalance())
+                        .transactionId(UUID.randomUUID().toString().replace("-",))
+                        .transactedAt(LocalDateTime.now())
+                        .build()
+        )
+    }
+    )
+
+
+
+
+
+}

--- a/src/main/java/com/example/Account/type/TransactionResultType.java
+++ b/src/main/java/com/example/Account/type/TransactionResultType.java
@@ -1,0 +1,5 @@
+package com.example.Account.type;
+
+public enum TransactionResultType {
+    S, F
+}

--- a/src/main/java/com/example/Account/type/TransactionType.java
+++ b/src/main/java/com/example/Account/type/TransactionType.java
@@ -1,0 +1,5 @@
+package com.example.Account.type;
+
+public enum TransactionType {
+    USE, CANCEL
+}


### PR DESCRIPTION
feat : [004-Account-Update] 잔액 사용
- POST /transaction/use
- 파라미터 : 사용자 아이디, 계좌 번호, 거래 금액
- 정책 : 사용자 없는 경우, 사용자 아이디와 계좌 소유주가 다른 경우, 계좌가 이미 해지 상태인 경우, 거래금액이 잔액보다 큰 경우,
거래금액이 너무 작거나 큰 경우 실패 응답
- 해당 계좌에서 거래(사용, 사용 취소)가 진행 중일 때 다른 거래 요청이 오는 경우 해당 거래가 동시에 잘못 처리되는 것을 방지해야 한다.
- 성공 응답: 계좌번호, 거래 결과 코드(성공/실패), 거래 아이디, 거래금액, 거래일시