### PR TITLE
[005-Account-Update] 잔액 사용 취소

### DIFF
--- a/src/main/java/com/example/Account/controller/TransactionController.java
+++ b/src/main/java/com/example/Account/controller/TransactionController.java
@@ -7,6 +7,7 @@ package com.example.Account.controller;
  * 3. 거래 확인
  */
 
+import com.example.Account.dto.CancelBalance;
 import com.example.Account.dto.UseBalance;
 import com.example.Account.exception.AccountException;
 import com.example.Account.service.TransactionService;
@@ -38,6 +39,27 @@ public class TransactionController {
             log.error("Failed to use balance.");
 
             transactionService.saveFailedUseTransaction(
+                    request.getAccountNumber(),
+                    request.getAmount()
+            );
+
+            throw e;
+        }
+    }
+
+    @PostMapping("/transaction/cancel")
+    public CancelBalance.Response cancelBalance(
+            @Valid @RequestBody CancelBalance.Request request
+    ) {
+        try {
+            return useBalance.Response.from(
+                    transactionService.cancelBalance(request.getTransactionId(),
+                            request.getAccountNumber(), request.getAmount())
+            );
+        } catch (AccountException e) {
+            log.error("Failed to use balance.");
+
+            transactionService.saveFailedCancelTransaction(
                     request.getAccountNumber(),
                     request.getAmount()
             );

--- a/src/main/java/com/example/Account/domain/Account.java
+++ b/src/main/java/com/example/Account/domain/Account.java
@@ -49,4 +49,11 @@ public class Account {
         }
         balance -= amount;
     }
+
+    public void cancelBalance(Long amount) {
+        if (amount < 0) {
+            throw new AccountException(ErrorCode.INVALID_REQUEST);
+        }
+        balance += amount;
+    }
 }

--- a/src/main/java/com/example/Account/dto/CancelBalance.java
+++ b/src/main/java/com/example/Account/dto/CancelBalance.java
@@ -1,0 +1,35 @@
+package com.example.Account.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.*;
+
+public class CancelBalance {
+
+    /**
+     * {
+     *     "transactionId": "skdhfkhk25hdksjfh",
+     *     "accountNumber" : "1000000000",
+     *     "amount": 1000
+     * }
+     */
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class Request {
+        @NotBlank
+        private String transactionId;
+
+        @NotBlank
+        @Size(min = 10, max = 10)
+        private String accountNumber;
+
+        @NotNull
+        @Min(10)
+        @Max(1000_000_000)
+        private Long amount;
+    }
+
+}

--- a/src/main/java/com/example/Account/service/TransactionService.java
+++ b/src/main/java/com/example/Account/service/TransactionService.java
@@ -78,12 +78,47 @@ public class TransactionService {
                         .account(account)
                         .amount(amount)
                         .balanceSnapshot(account.getBalance())
-                        .transactionId(UUID.randomUUID().toString().replace("-",))
+                        .transactionId(UUID.randomUUID().toString().replace("-", ))
                         .transactedAt(LocalDateTime.now())
                         .build()
         )
     }
-    )
+
+    @Transactional
+    public TransactionDto cancelBalance(
+            String transactionId,
+            String accountNumber,
+            Long amount
+    ) {
+        Transaction transaction = transactionRepository.findByTransactionId(transactionId)
+                .orElseThrow(() -> new AccountException(ErrorCode.TRANSACTION_NOT_FOUND));
+
+        Account account = accountRepository.findByAccountNumber(accountNumber)
+                .orElseThrow(() -> new AccountException(ErrorCode.ACCOUNT_NOT_FOUND));
+
+        validateCancelBalance(transaction, account, amount);
+
+        account.cancelBalance(amount);
+
+        return TransactionDto.fromEntity(
+                saveAndGetTransaction(CANCEL, S, account, amount)
+        );
+    }
+
+    private void validateCancelBalance(Transaction transaction, Account account, Long amount) {
+        if (!Objects.equals(transaction.getAccount().getId(), account.getId())) {
+            throw new AccountException(ErrorCode.TRANSACTION_ACCOUNT_UN_MATCH);
+        }
+        if (!Objects.equals(transaction.getAmount(), amount)) {
+            throw new AccountException(ErrorCode.CANCEL_MUST_FULLY);
+        }
+        if (transaction.getTransactedAt().isBefore(LocalDateTime.now().minusYears(1))) {
+            throw new AccountException(ErrorCode.TOO_OLD_ORDER_TO_CANCEL);
+        }
+
+    }
+}
+
 
 
 


### PR DESCRIPTION
feat : [005-Account-Update] 잔액 사용 취소

- POST /transaction/cancel
- 파라미터 : 거래 아이디, 계좌번호, 취소 요청 금액
- 정책 : 거래 아이디에 해당하는 거래가 없는 경우, 계좌가 없는 경우, 거래와 계좌가 일치하지 않는 경우 거래금액과 거래 취소 금액이 다른경우(부분 취소 불가능) 실패 응답
- 1년이 넘은 거래는 사용 취소 불가능
- 해당 계좌에서 거래(사용, 사용 취소)가 진행 중일 때 다른 거래 요청이 오는 경우 해당 거래가 동시에 잘못 처리되는 것을 방지해야 한다.
- 성공 응답: 계좌번호, 거래 결과 코드(성공/실패), 거래 아이디, 거래금액, 거래일