### PR TITLE
[005-Account-Update] 잔액 사용 확인

### DIFF
--- a/src/main/java/com/example/Account/controller/TransactionController.java
+++ b/src/main/java/com/example/Account/controller/TransactionController.java
@@ -8,14 +8,13 @@ package com.example.Account.controller;
  */
 
 import com.example.Account.dto.CancelBalance;
+import com.example.Account.dto.QueryTransactionResponse;
 import com.example.Account.dto.UseBalance;
 import com.example.Account.exception.AccountException;
 import com.example.Account.service.TransactionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -66,6 +65,13 @@ public class TransactionController {
 
             throw e;
         }
+    }
+    @GetMapping("/transaction/{transactionId}")
+    public QueryTransactionResponse queryTransaction(
+            @PathVariable String transactionId) {
+        return QueryTransactionResponse.from(
+                transactionService.queryTransaction(transactionId)
+        );
     }
 
 }

--- a/src/main/java/com/example/Account/dto/QueryTransactionResponse.java
+++ b/src/main/java/com/example/Account/dto/QueryTransactionResponse.java
@@ -1,0 +1,32 @@
+package com.example.Account.dto;
+
+import com.example.Account.type.TransactionResultType;
+import com.example.Account.type.TransactionType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class QueryTransactionResponse {
+    private String accountNumber;
+    private TransactionType transactionType;
+    private TransactionResultType transactionResultType;
+    private String transactionId;
+    private Long amount;
+    public LocalDateTime transactedAt;
+
+    public static QueryTransactionResponse from(TransactionDto transactionDto) {
+        return QueryTransactionResponse.builder()
+                .accountNumber(transactionDto.getAccountNumber())
+                .transactionType(transactionDto.getTransactionType())
+                .transactionResultType(transactionDto.getTransactionResultType())
+                .transactionId(transactionDto.getTransactionId())
+                .amount(transactionDto.getAmount())
+                .transactedAt(transactionDto.getTransactedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/Account/service/TransactionService.java
+++ b/src/main/java/com/example/Account/service/TransactionService.java
@@ -117,6 +117,19 @@ public class TransactionService {
         }
 
     }
+    @Transactional
+    public void saveFailedCancelTransaction(String accountNumber, Long amount) {
+        Account account = accountRepository.findByAccountNumber(accountNumber)
+                .orElseThrow(() -> new AccountException(ErrorCode.ACCOUNT_NOT_FOUND));
+
+        saveAndGetTransaction(CANCEL, F, account, amount);
+    }
+
+    public TransactionDto queryTransaction(String transactionId) {
+        return TransactionDto.fromEntity(transactionRepository.findByTransactionId(transactionId)
+                .orElseThrow(() -> new AccountException(ErrorCode.TRANSACTION_NOT_FOUND))
+        );
+    }
 }
 
 


### PR DESCRIPTION
feat : [005-Account-Update] 잔액 사용 확인
- GET /transaction/{transactionId}
- 파라미터 : 거래 아이디
- 정책 : 해당 거래 아이디의 거래가 없는 경우 실패 응답
- 성공 응답 : 계좌번호, 거래종류(잔액 사용, 잔액 사용 취소), 거래 결과 코드(성공/실패), 거래 아이디, 거래금액, 거래일시
- 실패한 거래(사용/사용취소)도 거래를 확인할 수 있도록 합니다.